### PR TITLE
Fix ntp

### DIFF
--- a/rippled.cfg
+++ b/rippled.cfg
@@ -50,9 +50,6 @@ full
 0
 
 [sntp_servers]
-time.windows.com
-time.apple.com
-time.nist.gov
 pool.ntp.org
 
 [rpc_allow_remote]

--- a/tasks/install-ntp.yml
+++ b/tasks/install-ntp.yml
@@ -1,0 +1,2 @@
+- name: Install ntpd
+  apt: update_cache=true name=ntp


### PR DESCRIPTION
Change rippled.cfg to only use pool.ntp.org as sntp_servers
Add ansible task for install ntpd
[Finishes #91205636]