### PR TITLE
[TASK] Exclude validation tracker node

### DIFF
--- a/validators.yml
+++ b/validators.yml
@@ -50,11 +50,6 @@ validators:
     port: 51235
     region: ap-northeast-1
     uuid: f1802428-476d-44e8-ad24-92d715c66b08
-  - ip: 54.94.245.104
-    key: n9Kk6U5nSF8EggfmTpMdna96UuXWAVwSsDSXRkXeZ5vLcAFk77tr
-    port: 51235
-    region: sa-east-1
-    uuid: 3f94c917-c5a8-410b-93a8-9636b75a1fc8
   - ip: 41.79.78.42
     key: n9LeE7e1c35m96BfFbUu1HKyJfqwiPvwNk6YxT5ewuZYsvwZqprp
     port: 51235


### PR DESCRIPTION
This node needs more extensive logging. Currently validation tracking cannot perform after this node is configured by the playbook.

Removing it from the list for now until it can be handled correctly in the playbook.