### PR TITLE
[TASK] Update rippled to latest version (DEC-121)

### DIFF
--- a/plays/restart-network.yml
+++ b/plays/restart-network.yml
@@ -10,7 +10,7 @@
     - name: Install apt repo key
       apt_key: url=http://mirrors.ripple.com/mirrors.ripple.com.gpg.key
     - name: Install rippled
-      apt: update_cache=true name=rippled
+      apt: update_cache=true state=latest name=rippled
     - name: Make rippled data directories
       file: state=directory owner=rippled group=rippled path=/mnt/rippled/db/
     - name: Make rippled log directory

--- a/rippled.cfg
+++ b/rippled.cfg
@@ -74,11 +74,6 @@ path=/mnt/rippled/db/nudb
 {{validator_private_key}}
 {% endif %}
 
-{% if validator_key %}
-[validation_public_key]
-{{validator_key}}
-{% endif %}
-
 [validators_site]
 rippletest.net
 


### PR DESCRIPTION
Running the restart-network playbook will now get all hosts on the latest rippled version.
Removed obsolete `[validation_public_key]` from rippled.cfg